### PR TITLE
Fix MSTAR data loading

### DIFF
--- a/src/torchcvnn/datasets/mstar/dataset.py
+++ b/src/torchcvnn/datasets/mstar/dataset.py
@@ -226,7 +226,13 @@ class MSTARTargets(Dataset):
             if not sub_dir.exists():
                 logging.warning(f"Directory {sub_dir} does not exist.")
                 continue
-            self.data_files.update(gather_mstar_datafiles(sub_dir, target_name_depth))
+            # Append the data files from the sub-dataset
+            for key, value in gather_mstar_datafiles(
+                sub_dir, target_name_depth
+            ).items():
+                if key not in self.data_files:
+                    self.data_files[key] = []
+                self.data_files[key].extend(value)
         self.class_names = list(self.data_files.keys())
 
         # We then count how many samples have been loaded for all the classes

--- a/src/torchcvnn/datasets/mstar/dataset.py
+++ b/src/torchcvnn/datasets/mstar/dataset.py
@@ -149,7 +149,6 @@ def gather_mstar_datafiles(rootdir: pathlib.Path, target_name_depth: int = 1) ->
 
         logging.debug(f"Successfully parsed {filename} as a {target_name} sample.")
         data_files[target_name].append(filename)
-
     return data_files
 
 
@@ -165,6 +164,7 @@ class MSTARTargets(Dataset):
     This dataset object expects all the datasets to be unpacked in the same directory. We can parse the following :
 
     - MSTAR_PUBLIC_T_72_VARIANTS_CD1 : https://www.sdms.afrl.af.mil/index.php?collection=mstar&page=variants
+    - MSTAR_PUBLIC_T_72_VARIANTS_CD2 : https://www.sdms.afrl.af.mil/index.php?collection=mstar&page=variants
     - MSTAR_PUBLIC_MIXED_TARGETS_CD1 : https://www.sdms.afrl.af.mil/index.php?collection=mstar&page=mixed
     - MSTAR_PUBLIC_MIXED_TARGETS_CD2 : https://www.sdms.afrl.af.mil/index.php?collection=mstar&page=mixed
     - MSTAR_PUBLIC_TARGETS_CHIPS_T72_BMP2_BTR70_SLICY :
@@ -214,6 +214,7 @@ class MSTARTargets(Dataset):
         # with respect to a datafile
         sub_datasets = {
             "MSTAR_PUBLIC_T_72_VARIANTS_CD1": 2,
+            "MSTAR_PUBLIC_T_72_VARIANTS_CD2": 2,
             "MSTAR_PUBLIC_MIXED_TARGETS_CD1": 2,
             "MSTAR_PUBLIC_MIXED_TARGETS_CD2": 2,
             "MSTAR_PUBLIC_TARGETS_CHIPS_T72_BMP2_BTR70_SLICY": 3,


### PR DESCRIPTION
There was an issue in the aggregation of the samples found in the different collections.

There was also one collection missing.

With all these collections we get the following sample count :: 

```
{'A10': 567, 'A63': 573, 'A32': 572, 'A07': 573, 'A62': 573, 'A64': 1417, 'A05': 573, 'A04': 573, 'SLICY': 3101, 'BTR_60': 451, 'T62': 572, 'BRDM_2': 1415, 'ZSU_23_4': 1401, 'D7': 573, 'ZIL131': 573, '2S1': 1164, 'BMP2': 1285, 'BTR70': 429, 'T72': 1273}
```

And, in details : 

```
For /home/fix_jer/Datasets/MSTAR/MSTAR_PUBLIC_T_72_VARIANTS_CD1                                                                                                                                                                                                                           
Class A10 : 271 samples.                                                                                                                                                                                                                                                                  
Class A63 : 274 samples.                                                                                                                                                                                                                                                                  
Class A32 : 274 samples.
Class A07 : 274 samples.
Class A62 : 274 samples.
Class A64 : 697 samples.
Class A05 : 274 samples.
Class A04 : 274 samples.
For /home/fix_jer/Datasets/MSTAR/MSTAR_PUBLIC_T_72_VARIANTS_CD2
Class A10 : 296 samples.
Class A63 : 299 samples.
Class A32 : 298 samples.
Class A07 : 299 samples.
Class A62 : 299 samples.
Class A64 : 720 samples.
Class A05 : 299 samples.
Class A04 : 299 samples.
For /home/fix_jer/Datasets/MSTAR/MSTAR_PUBLIC_MIXED_TARGETS_CD1
Class SLICY : 1953 samples.
Class BTR_60 : 195 samples.
Class T62 : 273 samples.
Class BRDM_2 : 697 samples.
Class ZSU_23_4 : 696 samples.
Class D7 : 274 samples.
Class ZIL131 : 274 samples.
Class 2S1 : 577 samples.
For /home/fix_jer/Datasets/MSTAR/MSTAR_PUBLIC_MIXED_TARGETS_CD2
Class BTR_60 : 256 samples.
Class T62 : 299 samples.
Class BRDM_2 : 718 samples.
Class SLICY : 586 samples.
Class ZSU_23_4 : 705 samples.
Class D7 : 299 samples.
Class ZIL131 : 299 samples.
Class 2S1 : 587 samples.
For /home/fix_jer/Datasets/MSTAR/MSTAR_PUBLIC_TARGETS_CHIPS_T72_BMP2_BTR70_SLICY
Class BMP2 : 1285 samples.
Class BTR70 : 429 samples.
Class T72 : 1273 samples.
Class SLICY : 562 samples.
```
