### PR TITLE
Update PolSARtoTensor -> PolSAR

### DIFF
--- a/src/torchcvnn/transforms/transforms.py
+++ b/src/torchcvnn/transforms/transforms.py
@@ -270,7 +270,8 @@ class PolSAR(BaseTransform):
         >>> output = transform(input_data)  # Returns [HH, (HV+VH)/2, VV]
         
     Note:
-        Input data should have format Channels x Height x Width (CHW)
+        - Input data should have format Channels x Height x Width (CHW).
+        - By default, PolSAR always return HH polarization if out_channel is 1.
     """
     def __init__(self, out_channel: int) -> None:
         self.out_channel = out_channel


### PR DESCRIPTION
PolSAR handles multiple type of Polarimetric SAR images. Polarimetric channels could be HH, [HH, VV], [HH, HV, VH, VV].
Based on chosen output channels, PolSAR will handle the conversion accordingly. PolSAR always returns HH polarization if output channel is equal to 1.