### PR TITLE
build the html code cov and upload it alongside the doc website

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,29 +4,60 @@ on:
   push:
     branches:
       - main
-jobs:
-  deploy:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python: ["3.10"]      
 
-    permissions:
-      contents: write
-      pages: write
+jobs:
+
+  codecov:
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: "3.10"
 
       - name: Cache python modules
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pkg-deps-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-docs
+          key: ${{ runner.os }}-pkg-deps-py310-test-${{ hashFiles('pyproject.toml') }}-docs
+
+      - name: Install torchcvnn and its test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install -r tests/requirements.txt
+
+      - name: Run pytest tests
+        run: cd tests && pytest --doctest-modules --cov=torchcvnn --cov-report=html
+
+      - name: Upload the codecov html report assets
+        uses: actions/upload-artifact@v4
+        with:
+          path: tests/htmlcov
+          name: htmlcov
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [codecov]
+
+    permissions:
+      contents: write
+      pages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Cache python modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pkg-deps-py310-${{ hashFiles('pyproject.toml') }}-docs
 
       - name: Install torchcvnn and its doc dependencies
         run: |
@@ -36,6 +67,12 @@ jobs:
       - name: Build HTML
         run : |
           cd docs && make html
+
+      - name: Download the code coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: htmlcov
+          path: docs/_build/html/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ">= 3.8 < 3.12"
+
       - name: Install torchcvnn dependencies
         run: |
           python -m pip install .
+
       - name: Install pytest dependencies
         run: |
           pip install -r tests/requirements.txt
+
       - name: Run pytest tests
         run: cd tests && pytest --doctest-modules --junitxml=junit/test-results.xml --cov=torchcvnn --cov-report=xml --cov-report=html

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,9 @@ This is a library that uses `pytorch <https://pytorch.org>`_ as a back-end for c
 
 It was initially developed by Victor Dhédin and Jérémie Levi during their third year project at `CentraleSupélec <https://www.centralesupelec.fr/>`_. 
 
-You can access it on github 
+You can access it on github.
+
+You can access the code coverage report `here <https://torchcvnn.github.io/torchcvnn/htmlcov>`_.
 
 .. raw:: html
 


### PR DESCRIPTION
In this PR, we: 

- slightly refactor the test workflow
- adds the generation of the code cov in the doc pipeline and upload it alongside the website
- 