### PR TITLE
Remove unused learnable parameter from Cardioid activation

### DIFF
--- a/src/torchcvnn/nn/modules/activation.py
+++ b/src/torchcvnn/nn/modules/activation.py
@@ -283,7 +283,6 @@ class Cardioid(nn.Module):
 
     def __init__(self):
         super().__init__()
-        self.b = torch.nn.Parameter(torch.tensor(0.0, dtype=torch.float), True)
 
     def forward(self, z: torch.Tensor):
         """


### PR DESCRIPTION
`b` parameter defined in the Cardioid constructor is not used in `forward` method so it should be removed to not waste GPU memory