### PR TITLE
fix incorrect bounds for the center_crop function, fix #83

### DIFF
--- a/src/torchcvnn/transforms/functional.py
+++ b/src/torchcvnn/transforms/functional.py
@@ -278,8 +278,8 @@ def center_crop(x: np.ndarray | torch.Tensor, height: int, width: int) -> np.nda
         >>> cropped.shape
         torch.Size([3, 60, 60])
     """
-    l_h = max(0, x.shape[0] // 2 - height // 2)
-    l_w = max(0, x.shape[0] // 2 - width // 2)
+    l_h = max(0, x.shape[1] // 2 - height // 2)
+    l_w = max(0, x.shape[2] // 2 - width // 2)
     r_h = l_h + height
     r_w = l_w + width
     return x[:, l_h:r_h, l_w:r_w]


### PR DESCRIPTION
This fixes the boundaries of the center_crop function. This was also affecting downstream functions such as `FFTResize`